### PR TITLE
ci: route site workflow through just

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [main]
 jobs:
-  ci:
+  quality:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -12,7 +12,13 @@ jobs:
         with:
           node-version: 20
           cache: "pnpm"
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
       - run: pnpm install
-      - run: pnpm prettier --check .
-      - run: pnpm astro check
-      - run: pnpm build
+      - name: Format
+        run: just format
+      - name: Lint
+        run: just lint
+      - name: Build
+        run: just build

--- a/justfile
+++ b/justfile
@@ -1,0 +1,17 @@
+default:
+    @just --list
+
+run:
+    pnpm dev
+
+build:
+    pnpm build
+
+format:
+    pnpm prettier --check .
+
+lint:
+    pnpm check
+
+ci: format lint build
+    @:


### PR DESCRIPTION
Why: The site workflow duplicated the repo task commands across direct CI steps with no repo-level command surface. A repo-level task surface keeps local use, CI, and automation aligned.

How: This adds a repo-root justfile with run, build, format, lint, and ci recipes, then updates the GitHub workflow to install just and call those recipes explicitly.